### PR TITLE
Add architectures

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,6 +41,6 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64,linux/ppc64le
+          platforms: linux/amd64,linux/386,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/386,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/arm/v7,linux/arm/v6
+          # platforms: linux/amd64,linux/386,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/386,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 [![Docker Image CI](https://github.com/ismvru/pytest/actions/workflows/docker-image.yml/badge.svg)](https://github.com/ismvru/pytest/actions/workflows/docker-image.yml)
 ![Docker Pulls](https://img.shields.io/docker/pulls/ismv/pytest)
-![Docker Image Version (latest by date) amd64](https://img.shields.io/docker/v/ismv/pytest?arch=amd64&label=image%20version%20amd64)
-![Docker Image Version (latest by date) arm64](https://img.shields.io/docker/v/ismv/pytest?arch=arm64&label=image%20version%20arm64)
-![Docker Image Version (latest by date) ppc64le](https://img.shields.io/docker/v/ismv/pytest?arch=ppc64le&label=image%20version%20ppc64le)
 
 - [pytest-docker](#pytest-docker)
   - [Usage](#usage)


### PR DESCRIPTION
Now docker image builds for:

- linux/amd64
- linux/386
- linux/arm64
- linux/ppc64le
- linux/s390x
- linux/arm/v7
- linux/arm/v6